### PR TITLE
Update README "Custom Axios Instance" example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const axiosInstance = axios.create(axios.create({
   baseURL: '/api/',
   timeout: 2000,
   headers: { 'X-Custom-Header': 'foobar' }
-})
+}))
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ render() {
 
 Create an axios instance
 ```js
-const axiosInstance = axios.create(axios.create({
+const axiosInstance = axios.create({
   baseURL: '/api/',
   timeout: 2000,
   headers: { 'X-Custom-Header': 'foobar' }
-}))
+})
 
 ```
 


### PR DESCRIPTION
The example is missing a closing parenthesis.