### PR TITLE
Debounce imediate

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,16 @@ $ npm install react-axios
 ```js
 <Request
   instance={axios.create({})} /* custom instance of axios - optional */
-  method="" /* required */
-  url="" /* required */
+  method="" /* get, delete, head, post, put and patch - required */
+  url="" /*  url endpoint to be requested - required */
   data="" /* post data - optional */
   config="" /* axios config - optional */
-  debounce=200 /* minimum time between calls - optional */
+  debounce={200} /* minimum time between requests events - optional */
+  debounceImmediate={true} /* make the request on the beginning or trailing end of debounce - optional */
   isReady={true} /* can make the axios request - optional */
-  onSuccess={(response)=>{}} /* optional */
-  onLoading={()=>{}} /* optional */
-  onError=(error)=>{} /* optional */
+  onSuccess={(response)=>{}} /* called on success of axios request - optional */
+  onLoading={()=>{}} /* called on start of axios request - optional */
+  onError=(error)=>{} /* called on error of axios request - optional */
 />
 ```
 

--- a/__tests__/utils.spec.js
+++ b/__tests__/utils.spec.js
@@ -4,34 +4,34 @@ import { Request, Get, Delete, Head, Post, Put, Patch } from '../src/index'
 
 const debounceTest = new Promise(
   (resolve) => {
+    let val = 0
     let count = 0
     // create a debounce function
-    const debounceFunc = debounce(()=>{count++}, 3)
-    debounceFunc() // ignored count=0
-    debounceFunc() // ignored count=0
-    debounceFunc() // ignored count=0
-    debounceFunc() // called  count=1
-    setTimeout(debounceFunc, 5) // called count=2
+    const debounceFunc = debounce((arg)=>{val = arg; count++}, 3)
+    debounceFunc(1) // ignored val=1, count=0
+    debounceFunc(2) // ignored val=2, count=0
+    debounceFunc(3) // ignored val=3, count=0
+    debounceFunc(4) // called  val=4, count=1
+    //setTimeout(debounceFunc, 5) // called count=2
     setTimeout(() => {
-      resolve(count) // count should be 2
-    }, 25)
-    debounce(()=>{count++}, 3, true)
+      resolve(count) // val should be 4, count should be 1
+    }, 50)
   }
 )
 
 const debounceTestImmediate = new Promise(
   (resolve) => {
+    let val = 0
     let count = 0
     // create a debounce function
-    const debounceFunc = debounce(()=>{count++}, 3, true)
-    debounceFunc() // called count=1
-    debounceFunc() // ignored count=1
-    debounceFunc() // ignored count=1
-    debounceFunc() // ignored count=1
-    setTimeout(debounceFunc, 5) // called count=2
+    const debounceFunc = debounce((arg)=>{val = arg; count++}, 3, true)
+    debounceFunc(1) // called val=1, count=1
+    debounceFunc(2) // ignored val=2, count=1
+    debounceFunc(3) // ignored val=3, count=1
+    debounceFunc(4) // called val=4, count=2
     setTimeout(() => {
-      resolve(count) // count should be 2
-    }, 25)
+      resolve(count) // val should be 4, count should be 2
+    }, 50)
   }
 )
 
@@ -44,7 +44,7 @@ describe('utils', () => {
 
     test('debounce test', () => {
       return debounceTest.then((res)=> {
-        expect(res).toBe(2)
+        expect(res).toBe(1)
       })
     })
     test('debounce test immediate', () => {

--- a/examples/advanced/app.js
+++ b/examples/advanced/app.js
@@ -15,39 +15,50 @@ class App extends React.Component {
   }
 
   testUnmount() {
-    this.setState({ isReady: true, url: '/api/cancel/?t='+new Date().getTime(), debounce: 0, unmount: false })
-    setTimeout(()=>{
+    console.log('testUnmount: make request')
+    this.setState({ isReady: true, url: '/api/cancel/?t='+new Date().getTime(), debounce: 200, unmount: false })
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      console.log('testUnmount: unmount component')
       this.setState({ unmount: true, isLoading: false, isReady: true })
     }, 500)
+  }
+
+  renderStatus() {
+    if(!this.state.unmount) {
+      return (
+        <Request
+          isReady={this.state.isReady}
+          method="get"
+          debounce={this.state.debounce}
+          url={this.state.url}
+          onSuccess={()=>this.setState({ isReady: false, isLoading: false })}
+          onLoading={()=>this.setState({ isLoading: true })}
+          onError={()=>this.setState({ isReady: false, isLoading: false })}
+        >
+          {(error, response, isLoading) => {
+            if(error) {
+              return (<div>Something bad happened: {error.message}</div>)
+            } else if(isLoading) {
+              return (<div className="loader"></div>)
+            } else if(response !== null) {
+              return (<div>{response.data.message}</div>)
+            }
+            return <div>Click a button to test its action.</div>
+          }}
+        </Request>
+      )
+    }
+    return (<span>Component unmounted.</span>)
   }
 
   render() {
     return (
       <div>
         <code>
-          {!this.state.unmount && <Request
-            isReady={this.state.isReady}
-            method="get"
-            debounce={this.state.debounce}
-            url={this.state.url}
-            onSuccess={()=>this.setState({ isReady: false, isLoading: false })}
-            onLoading={()=>this.setState({ isLoading: true })}
-            onError={()=>this.setState({ isReady: false, isLoading: false })}
-          >
-            {(error, response, isLoading) => {
-              if(error) {
-                return (<div>Something bad happened: {error.message}</div>)
-              } else if(isLoading) {
-                return (<div className="loader"></div>)
-              } else if(response !== null) {
-                return (<div>{response.data.message}</div>)
-              }
-              return <div>Click a button to test its action.</div>
-            }}
-          </Request>}
-          {this.state.unmount && 'Component unmounted.'}
+          {this.renderStatus()}
         </code>
-        <button className="info" disabled={this.state.isLoading} onClick={()=>this.setState({ isReady: true, url: '/api/advanced', debounce: 200, unmount: false })}>
+        <button className="info" onClick={()=>this.setState({ isReady: true, url: '/api/advanced', debounce: 200, unmount: false })}>
           Make API Request
         </button>
         <button className="warning" onClick={()=>this.setState({ isReady: true, url: '/api/debounce/?t='+new Date().getTime(), debounce: 250, unmount: false })}>
@@ -59,7 +70,7 @@ class App extends React.Component {
         <button className="danger" disabled={this.state.isLoading} onClick={()=>this.setState({ isReady: true, url: '/error', debounce: 200, unmount: false })}>
           Force API Error
         </button>
-        <button className="danger" disabled={this.state.isLoading} onClick={()=>this.testUnmount()}>
+        <button className="danger" disabled={this.state.unmount} onClick={()=>this.testUnmount()}>
           Unmount Test
         </button>
       </div>

--- a/examples/style.css
+++ b/examples/style.css
@@ -32,7 +32,7 @@ code {
 }
 
 button {
-
+ margin-right: 5px;
 }
 
 .loader {

--- a/src/components/Request.js
+++ b/src/components/Request.js
@@ -41,7 +41,7 @@ class Request extends React.Component {
   }
 
   setupDebounce(props) {
-    this.debounceMakeRequest = debounce(this.makeRequest, props.debounce)
+    this.debounceMakeRequest = debounce(this.makeRequest, props.debounce, props.debounceImmediate)
   }
 
   getConfig(props) {
@@ -96,6 +96,7 @@ Request.defaultProps = {
   data: {},
   config: {},
   debounce: 200,
+  debounceImmediate: true,
   isReady: true
 }
 
@@ -107,6 +108,7 @@ Request.propTypes = {
   config: PropTypes.object,
   isReady: PropTypes.bool,
   debounce: PropTypes.number,
+  debounceImmediate: PropTypes.bool,
   onSuccess: PropTypes.func,
   onLoading: PropTypes.func,
   onError: PropTypes.func,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,12 +1,16 @@
 export function debounce(func, wait, immediate) {
   let timeout
+  let initialArgs
   return function () {
     let context = this, args = arguments
-    if (immediate && !timeout) func.apply(context, args)
+    if (!timeout) {
+      initialArgs = args
+      if (immediate) func.apply(context, args)
+    }
     clearTimeout(timeout)
     timeout = setTimeout(function () {
       timeout = null
-      if (!immediate) func.apply(context, args)
+      if (!immediate || (immediate && initialArgs != args)) func.apply(context, args)
     }, wait)
   }
 }


### PR DESCRIPTION
This PR addresses issue #10 where initial request was being called after debounce instead of before.
Default now is debounceImmediate=true. 
If props change before debounce timeout the current request will be canceled and a new one will be issued to get the request and props back in sync.