### PR TITLE
Add withAxios() to use with AxiosProvider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ npm install react-axios
 Include in your file
 
 ```js
-import { AxiosProvider, Request, Get, Delete, Head, Post, Put, Patch } from 'react-axios'
+import { AxiosProvider, Request, Get, Delete, Head, Post, Put, Patch, withAxios } from 'react-axios'
 ```
 
 Performing a `GET` request
@@ -120,4 +120,24 @@ Or pass down through props
     ...
   }}
 </Get>
+```
+
+Retrieve from custom provider (when you need to directly use axios).
+The default instance will be passed if not inside an `<AxiosProvider/>`.
+```js
+const MyComponent = withAxios(class MyComponentImpl extends React.Component {
+  componentWillMount() {
+    this.props.axios('test').then(result => {
+      this.setState({ data: result.data })
+    })
+  }
+  render() {
+    const data = (this.state || {}).data
+    return <div>{JSON.stringify(data)}</div>
+  }
+})
+
+<AxiosProvider instance={axiosInstance}>
+  <MyComponent/>
+</AxiosProvider>
 ```

--- a/__tests__/utils.spec.js
+++ b/__tests__/utils.spec.js
@@ -1,6 +1,8 @@
+import axios from 'axios'
 import React from 'react'
+import renderer from 'react-test-renderer'
 import { debounce } from '../src/utils'
-import { Request, Get, Delete, Head, Post, Put, Patch } from '../src/index'
+import { AxiosProvider, Request, Get, Delete, Head, Post, Put, Patch, withAxios } from '../src/index'
 
 const debounceTest = new Promise(
   (resolve) => {
@@ -145,6 +147,34 @@ describe('components', () => {
     })
     test('is method=patch', () => {
       expect(component.props.method).toBe('patch')
+    })
+  })
+
+  describe('#withAxios', () => {
+    const Component = withAxios(props => {
+      props.onRendered(props.axios)
+      return <div/>
+    })
+    test('provides default instance', () => {
+      let seenAxios
+      renderer(
+        <Component onRendered={passedAxios => {
+          seenAxios = passedAxios
+        }}/>
+      )
+      expect(typeof seenAxios).toBe('function')
+    })
+    test('respects AxiosProvider', () => {
+      const axiosInstance = axios.create()
+      let seenAxios
+      renderer(
+        <AxiosProvider instance={axiosInstance}>
+          <Component onRendered={passedAxios => {
+            seenAxios = passedAxios
+          }}/>
+        </AxiosProvider>
+      )
+      expect(seenAxios).toBe(axiosInstance)
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "jest": "^17.0.3",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
+    "react-test-renderer": "^1.1.0",
     "webpack": "^1.13.3",
     "webpack-dev-middleware": "^1.8.4"
   }

--- a/src/components/AxiosProvider.js
+++ b/src/components/AxiosProvider.js
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import React from 'react'
 import PropTypes from 'prop-types'
 
@@ -28,3 +29,15 @@ AxiosProvider.propTypes = {
 }
 
 export default AxiosProvider
+
+export const withAxios = (WrappedComponent) => {
+  const AxiosExtracter = (props, context) => {
+    return <WrappedComponent axios={context.axios || axios} {...props}/>
+  }
+
+  AxiosExtracter.contextTypes = {
+    axios: PropTypes.func
+  }
+
+  return AxiosExtracter
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import AxiosProvider from './components/AxiosProvider'
+import AxiosProvider, { withAxios } from './components/AxiosProvider'
 import Request from './components/Request'
 import RequestWrapper from './components/RequestWrapper'
 
@@ -10,5 +10,6 @@ module.exports = {
   Head: RequestWrapper('head'),
   Post: RequestWrapper('post'),
   Put: RequestWrapper('put'),
-  Patch: RequestWrapper('patch')
+  Patch: RequestWrapper('patch'),
+  withAxios: withAxios
 }


### PR DESCRIPTION
The concept of specifying a default axios instance through context
is useful. Sometimes one needs direct access to the axios API (and
cannot use the Request component). The withAxios function is a higher
order component which gives custom components access to the axios
instance.