### PR TITLE
Fix isCancel missing using custom axios instance

### DIFF
--- a/src/components/Request.js
+++ b/src/components/Request.js
@@ -86,7 +86,7 @@ class Request extends React.Component {
       if (!this._mounted) {
         return
       }
-      if (!_axios.isCancel(err)) {
+      if (!axios.isCancel(err)) {
         this.setState({ isLoading: false, response: err.response, error: err })
         if (typeof this.props.onError === 'function') {
           this.props.onError(err)


### PR DESCRIPTION
Custom axios instance don't have isCancel helper function.
I can resolve this issue using this on my project code:
```
const apiInstance = axios.create({...})
apiInstance.isCancel = axios.isCancel
```

Or directly using native axios isCancel on Request render method.