### PR TITLE
Fixed Get component

### DIFF
--- a/src/components/Request.js
+++ b/src/components/Request.js
@@ -115,7 +115,6 @@ Request.contextTypes = {
 Request.defaultProps = {
   url: undefined,
   method: 'get',
-  data: {},
   config: {},
   debounce: 200,
   debounceImmediate: true,


### PR DESCRIPTION
Platform: React Native
OS: IOS, Android

If I use `<Get/>` component I get a timeout error. But if I use the Axios instance from the context - everything work.
It because If to set 'data' field to the config of the `GET` request - request returns the timeout error